### PR TITLE
move instHandler out

### DIFF
--- a/DomCon/control_type.go
+++ b/DomCon/control_type.go
@@ -17,6 +17,7 @@ type DomListControl struct {
 	DomainList       map[string]*Domain
 	domainListMutex  sync.Mutex
 	DomainListStatus *domStatus.DomainListStatus
+	libvirtInst      *libvirt.Connect
 }
 
 // 각 도메인을 관리하는 인메모리 구조체

--- a/DomCon/domain_list.go
+++ b/DomCon/domain_list.go
@@ -26,6 +26,10 @@ func DomListConGen() *DomListControl {
 	}
 } // 전역적으로 사용되는 도메인 리스트 컨트롤러 생성
 
+func (DC *DomListControl) SetLibvirt(inst *libvirt.Connect) {
+	DC.libvirtInst = inst
+}
+
 func (DC *DomListControl) AddNewDomain(domain *Domain, uuid string) error {
 	DC.domainListMutex.Lock()
 	defer DC.domainListMutex.Unlock()
@@ -48,12 +52,12 @@ func (DC *DomListControl) AddExistingDomain(domain *Domain, uuid string) {
 
 // Exstring Domain only called from initial booting, and adding specs is not its role
 
-func (DC *DomListControl) GetDomain(uuid string, LibvirtInst *libvirt.Connect) (*Domain, error) {
+func (DC *DomListControl) GetDomain(uuid string) (*Domain, error) {
 	DC.domainListMutex.Lock()
 	domain, Exist := DC.DomainList[uuid]
 	DC.domainListMutex.Unlock()
 	if !Exist {
-		DomainSeeker := DomSeekUUIDFactory(LibvirtInst, uuid)
+		DomainSeeker := DomSeekUUIDFactory(DC.libvirtInst, uuid)
 		dom, err := DomainSeeker.ReturnDomain()
 		if err != nil {
 			return nil, err
@@ -75,7 +79,7 @@ func (DC *DomListControl) DeleteDomain(Domain *libvirt.Domain, uuid string, vcpu
 	DC.DomainListStatus.TakeAllocatedCPU(vcpu)
 }
 
-func (DC *DomListControl) FindAndDeleteDomain(LibvirtInst *libvirt.Connect, uuid string) error {
+func (DC *DomListControl) FindAndDeleteDomain(uuid string) error {
 	//아직 활용처가 없어서, vcpu 삭제를 추가하지 않았음/
 	// DeleteDomain 함수의 TakeAllocatedCPU 호출을 참고..
 	DC.domainListMutex.Lock()
@@ -83,7 +87,7 @@ func (DC *DomListControl) FindAndDeleteDomain(LibvirtInst *libvirt.Connect, uuid
 	DC.domainListMutex.Unlock()
 
 	if !Exist {
-		DomainSeeker := DomSeekUUIDFactory(LibvirtInst, uuid)
+		DomainSeeker := DomSeekUUIDFactory(DC.libvirtInst, uuid)
 		dom, err := DomainSeeker.ReturnDomain()
 		if err != nil {
 			return virerr.ErrorGen(virerr.NoSuchDomain, fmt.Errorf("domain trying to delete already empty, uuid of %s, %w", uuid, err))
@@ -101,8 +105,8 @@ func (DC *DomListControl) FindAndDeleteDomain(LibvirtInst *libvirt.Connect, uuid
 	return nil
 }
 
-func (DC *DomListControl) retrieveDomainsByState(LibvirtInst *libvirt.Connect, state libvirt.ConnectListAllDomainsFlags, logger *zap.Logger) error {
-	domains, err := LibvirtInst.ListAllDomains(state)
+func (DC *DomListControl) retrieveDomainsByState(state libvirt.ConnectListAllDomainsFlags, logger *zap.Logger) error {
+	domains, err := DC.libvirtInst.ListAllDomains(state)
 	if err != nil {
 		logger.Fatal("Failed to retrieve domains", zap.Error(err))
 		return err
@@ -137,14 +141,14 @@ func (DC *DomListControl) retrieveDomainsByState(LibvirtInst *libvirt.Connect, s
 	return nil
 }
 
-func (DC *DomListControl) RetrieveAllDomain(LibvirtInst *libvirt.Connect, logger *zap.Logger) error {
+func (DC *DomListControl) RetrieveAllDomain(logger *zap.Logger) error {
 	logger.Info("Retrieving all domains from libvirt...")
 
-	if err := DC.retrieveDomainsByState(LibvirtInst, libvirt.CONNECT_LIST_DOMAINS_ACTIVE, logger); err != nil {
+	if err := DC.retrieveDomainsByState(libvirt.CONNECT_LIST_DOMAINS_ACTIVE, logger); err != nil {
 		return err
 	}
 
-	if err := DC.retrieveDomainsByState(LibvirtInst, libvirt.CONNECT_LIST_DOMAINS_INACTIVE, logger); err != nil {
+	if err := DC.retrieveDomainsByState(libvirt.CONNECT_LIST_DOMAINS_INACTIVE, logger); err != nil {
 		return err
 	}
 

--- a/api/Control.go
+++ b/api/Control.go
@@ -22,7 +22,7 @@ func (i *InstHandler) ForceShutDownVM(w http.ResponseWriter, r *http.Request) {
 		i.Logger.Error("failed to decode forceShutdown request", zap.Error(ERR))
 		return
 	}
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		ERR := virerr.ErrorJoin(err, fmt.Errorf("error shutting down vm, retreving Get domin error "))
 		resp.ResponseWriteErr(w, ERR, http.StatusInternalServerError)
@@ -70,7 +70,7 @@ func (i *InstHandler) DeleteVM(w http.ResponseWriter, r *http.Request) {
 	}
 	// uuid 가 적합한지 확인
 
-	domain, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	domain, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		ERR := virerr.ErrorJoin(err, fmt.Errorf("error deleting vm, retreving Get domin error "))
 		resp.ResponseWriteErr(w, ERR, http.StatusInternalServerError)

--- a/api/Create.go
+++ b/api/Create.go
@@ -24,7 +24,7 @@ func (i *InstHandler) BootVM(w http.ResponseWriter, r *http.Request) {
 
 	domCon, _ := i.domainConGetter()
 
-	DomainExisting, _ := domCon.GetDomain(param.UUID, i.LibvirtInst)
+	DomainExisting, _ := domCon.GetDomain(param.UUID)
 	if DomainExisting == nil {
 		resp.ResponseWriteErr(w, nil, http.StatusBadRequest)
 		i.Logger.Error("error handling booting vm, domain not found", zap.String("uuid", param.UUID))
@@ -64,7 +64,7 @@ func (i *InstHandler) CreateVMFromBase(w http.ResponseWriter, r *http.Request) {
 	}
 	i.Logger.Info("Handling Create VM", zap.String("uuid", param.UUID))
 
-	domainExisting, _ := domCon.GetDomain(param.UUID, i.LibvirtInst)
+	domainExisting, _ := domCon.GetDomain(param.UUID)
 	if domainExisting != nil {
 		resp.ResponseWriteErr(w, nil, http.StatusBadRequest)
 		i.Logger.Error("error handling creating vm, domain already exists", zap.String("uuid", param.UUID))

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -55,7 +55,7 @@ func (i *InstHandler) CreateSnapshot(w http.ResponseWriter, r *http.Request) {
 
 	i.Logger.Info("snapshot create start", zap.String("uuid", param.UUID), zap.String("snapshot_name", name))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("snapshot create failed - domain not found", zap.String("uuid", param.UUID), zap.Error(err))
@@ -95,7 +95,7 @@ func (i *InstHandler) CreateExternalSnapshot(w http.ResponseWriter, r *http.Requ
 
 	i.Logger.Info("external snapshot create start", zap.String("domain_uuid", param.UUID), zap.String("snapshot_name", name))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("external snapshot create failed - domain not found", zap.String("domain_uuid", param.UUID), zap.Error(err))
@@ -136,7 +136,7 @@ func (i *InstHandler) ListExternalSnapshots(w http.ResponseWriter, r *http.Reque
 
 	i.Logger.Info("external snapshot list start", zap.String("domain_uuid", param.UUID))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("external snapshot list failed - domain not found", zap.String("domain_uuid", param.UUID), zap.Error(err))
@@ -175,7 +175,7 @@ func (i *InstHandler) RevertExternalSnapshot(w http.ResponseWriter, r *http.Requ
 
 	i.Logger.Info("external snapshot revert start", zap.String("domain_uuid", param.UUID), zap.String("snapshot_name", param.Name))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("external snapshot revert failed - domain not found", zap.String("domain_uuid", param.UUID), zap.Error(err))
@@ -208,7 +208,7 @@ func (i *InstHandler) ListSnapshots(w http.ResponseWriter, r *http.Request) {
 
 	i.Logger.Info("snapshot list start", zap.String("uuid", param.UUID))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("snapshot list failed - domain not found", zap.String("uuid", param.UUID), zap.Error(err))
@@ -244,7 +244,7 @@ func (i *InstHandler) RevertSnapshot(w http.ResponseWriter, r *http.Request) {
 
 	i.Logger.Info("snapshot revert start", zap.String("uuid", param.UUID), zap.String("snapshot_name", param.Name))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("snapshot revert failed - domain not found", zap.String("uuid", param.UUID), zap.Error(err))
@@ -279,7 +279,7 @@ func (i *InstHandler) DeleteSnapshot(w http.ResponseWriter, r *http.Request) {
 
 	i.Logger.Info("snapshot delete start", zap.String("uuid", param.UUID), zap.String("snapshot_name", param.Name))
 
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		i.Logger.Error("snapshot delete failed - domain not found", zap.String("uuid", param.UUID), zap.Error(err))

--- a/api/status.go
+++ b/api/status.go
@@ -26,7 +26,7 @@ func (i *InstHandler) ReturnStatusUUID(w http.ResponseWriter, r *http.Request) {
 		return
 		// wrong parameter error 반환
 	}
-	dom, err := i.DomainControl.GetDomain(param.UUID, i.LibvirtInst)
+	dom, err := i.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, virerr.ErrorJoin(err, errors.New("error returning status from uuid")), http.StatusInternalServerError)
 	}

--- a/main.go
+++ b/main.go
@@ -24,8 +24,9 @@ func main() {
 	}
 
 	libvirtInst.LibvirtConnection()
+	libvirtInst.DomainControl.SetLibvirt(libvirtInst.LibvirtInst)
 	libvirtInst.DomainControl.DomainListStatus.Update()
-	if err := libvirtInst.DomainControl.RetrieveAllDomain(libvirtInst.LibvirtInst, logger); err != nil {
+	if err := libvirtInst.DomainControl.RetrieveAllDomain(logger); err != nil {
 		logger.Fatal("failed to retrieve domains on startup", zap.Error(err))
 	}
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / tech debt
- [ ] Docs / test

## Summary
libvirt.Con이 의미없이 인자로 전달되는 것이 아닌 내부 필드로 세팅후 참조할 수 있도록 수정

## Related Issue
Closes #98 

## Test Plan
- [x] `make test` passes
- [ ] Manually verified on libvirt environment
