### PR TITLE
migrate status api layer into splitted handler

### DIFF
--- a/DomCon/domain_list.go
+++ b/DomCon/domain_list.go
@@ -150,6 +150,10 @@ func (DC *DomListControl) RetrieveAllDomain(logger *zap.Logger) error {
 	return nil
 }
 
+func (DC *DomListControl) GetDomainListStatus() *domStatus.DomainListStatus {
+	return DC.DomainListStatus
+}
+
 ////////////////////////////////////////////////
 
 func (DC *DomListControl) BootSleepingCPU(domain *Domain) error {

--- a/api/Status/Status.go
+++ b/api/Status/Status.go
@@ -1,4 +1,4 @@
-package api
+package status
 
 import (
 	"errors"
@@ -6,32 +6,32 @@ import (
 
 	virerr "github.com/easy-cloud-Knet/KWS_Core/internal/error"
 	httputil "github.com/easy-cloud-Knet/KWS_Core/pkg/httputil"
-	"github.com/easy-cloud-Knet/KWS_Core/services/status"
+	svcstatus "github.com/easy-cloud-Knet/KWS_Core/services/status"
 	"go.uber.org/zap"
 )
 
-func (i *InstHandler) ReturnStatusUUID(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ReturnStatusUUID(w http.ResponseWriter, r *http.Request) {
 	param := &DomainStatusRequest{}
-	resp := httputil.ResponseGen[status.DataTypeHandler]("domain Status UUID")
+	resp := httputil.ResponseGen[svcstatus.DataTypeHandler]("domain Status UUID")
 
 	if err := httputil.HttpDecoder(r, param); err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusBadRequest)
 		return
 	}
-	i.Logger.Info("retreving domain status", zap.String("uuid", param.UUID))
+	h.Logger.Info("retreving domain status", zap.String("uuid", param.UUID))
 
-	outputStruct, err := status.DataTypeRouter(param.DataType)
+	outputStruct, err := svcstatus.DataTypeRouter(param.DataType)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusBadRequest)
 		return
-		// wrong parameter error 반환
 	}
-	dom, err := i.DomainControl.GetDomain(param.UUID)
+	dom, err := h.DomainControl.GetDomain(param.UUID)
 	if err != nil {
 		resp.ResponseWriteErr(w, virerr.ErrorJoin(err, errors.New("error returning status from uuid")), http.StatusInternalServerError)
+		return
 	}
 
-	DomainDetail := status.DomainDetailFactory(outputStruct, dom.Domain)
+	DomainDetail := svcstatus.DomainDetailFactory(outputStruct, dom.Domain)
 
 	if err := outputStruct.GetInfo(dom.Domain); err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
@@ -39,81 +39,74 @@ func (i *InstHandler) ReturnStatusUUID(w http.ResponseWriter, r *http.Request) {
 	}
 	DomainDetail.DataHandle = outputStruct
 	resp.ResponseWriteOK(w, &DomainDetail.DataHandle)
-
 }
 
-func (i *InstHandler) ReturnStatusHost(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ReturnStatusHost(w http.ResponseWriter, r *http.Request) {
 	param := &HostStatusRequest{}
-	resp := httputil.ResponseGen[status.HostDataTypeHandler]("Host Status Return")
+	resp := httputil.ResponseGen[svcstatus.HostDataTypeHandler]("Host Status Return")
 
 	if err := httputil.HttpDecoder(r, param); err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		return
 	}
 
-	dataHandle, err := status.HostDataTypeRouter(param.HostDataType)
+	dataHandle, err := svcstatus.HostDataTypeRouter(param.HostDataType)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		return
 	}
 
-	host, err := status.HostInfoHandler(dataHandle, i.DomainControl.DomainListStatus)
+	host, err := svcstatus.HostInfoHandler(dataHandle, h.DomainControl.GetDomainListStatus())
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
+		return
 	}
 
 	resp.ResponseWriteOK(w, &host.HostDataHandle)
 }
 
-func (i *InstHandler) ReturnInstAllInfo(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ReturnInstAllInfo(w http.ResponseWriter, r *http.Request) {
 	param := &InstInfoRequest{}
-	resp := httputil.ResponseGen[status.InstDataTypeHandler]("Inst Hardware Return")
+	resp := httputil.ResponseGen[svcstatus.InstDataTypeHandler]("Inst Hardware Return")
 
 	if err := httputil.HttpDecoder(r, param); err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
-		http.Error(w, "error decoding parameters", http.StatusBadRequest)
 		return
 	}
 
-	dataHandle, err := status.InstDataTypeRouter(param.InstDataType)
+	dataHandle, err := svcstatus.InstDataTypeRouter(param.InstDataType)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		return
 	}
-	inst, err := status.InstDetailFactory(dataHandle, i.LibvirtInst)
+	inst, err := svcstatus.InstDetailFactory(dataHandle, h.LibvirtInst)
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
+		return
 	}
 
 	resp.ResponseWriteOK(w, &inst.AllInstDataHandle)
 }
 
-// host 상태 조회는 두가지 에러를 반환할 수 있음.
-// 1. Routing 등에서 일어나는 에러, (host data 타입등이 잘못 입력 된 경우) , InvalidParameter
-// 2. 정확히 파악할 수 없는 오류, 사용하는 호스트 반환 패키지에서 반환되는 오류, , HostStatusError
-// 이 두가지는 내부 함수에서 파악하여 올리기 때문에, 추가 없이  ResponseWirteErr 호출해도 괜찮을 듯
-
-func (i *InstHandler) ReturnAllUUIDs(w http.ResponseWriter, r *http.Request) {
-	i.Logger.Info("ReturnAllUUIDs handler entered")
+func (h *Handler) ReturnAllUUIDs(w http.ResponseWriter, r *http.Request) {
+	h.Logger.Info("ReturnAllUUIDs handler entered")
 
 	resp := httputil.ResponseGen[UUIDListResponse]("Get All UUIDs")
 
-	uuids := i.DomainControl.GetAllUUIDs()
+	uuids := h.DomainControl.GetAllUUIDs()
 	respData := UUIDListResponse{UUIDs: uuids}
 
 	resp.ResponseWriteOK(w, &respData)
 }
 
-//////////////////////////////////////////////////////////////////
-
-func (i *InstHandler) GetAllDomainStates() ([]DomainStateResponse, error) {
-	domains, err := i.LibvirtInst.ListAllDomains(0)
+func (h *Handler) getAllDomainStates() ([]DomainStateResponse, error) {
+	domains, err := h.LibvirtInst.ListAllDomains(0)
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
 		for _, d := range domains {
-			d.Free() // libvirt의 도메인 객체 메모리 해제
+			d.Free()
 		}
 	}()
 
@@ -121,11 +114,11 @@ func (i *InstHandler) GetAllDomainStates() ([]DomainStateResponse, error) {
 	for _, domain := range domains {
 		uuid, err := domain.GetUUIDString()
 		if err != nil {
-			continue // UUID 조회 실패 시 건너뜀
+			continue
 		}
 		state, _, err := domain.GetState()
 		if err != nil {
-			continue // 상태 조회 실패 시 건너뜀
+			continue
 		}
 		result = append(result, DomainStateResponse{
 			UUID:        uuid,
@@ -135,12 +128,12 @@ func (i *InstHandler) GetAllDomainStates() ([]DomainStateResponse, error) {
 	return result, nil
 }
 
-func (i *InstHandler) ReturnAllDomainStates(w http.ResponseWriter, r *http.Request) {
-	i.Logger.Info("ReturnAllDomainStates handler entered")
+func (h *Handler) ReturnAllDomainStates(w http.ResponseWriter, r *http.Request) {
+	h.Logger.Info("ReturnAllDomainStates handler entered")
 
 	resp := httputil.ResponseGen[[]DomainStateResponse]("Get All Domain States")
 
-	states, err := i.GetAllDomainStates()
+	states, err := h.getAllDomainStates()
 	if err != nil {
 		resp.ResponseWriteErr(w, err, http.StatusInternalServerError)
 		return

--- a/api/Status/handler.go
+++ b/api/Status/handler.go
@@ -1,0 +1,28 @@
+package status
+
+import (
+	domCon "github.com/easy-cloud-Knet/KWS_Core/DomCon"
+	domStatus "github.com/easy-cloud-Knet/KWS_Core/DomCon/domainList_status"
+	"go.uber.org/zap"
+	"libvirt.org/go/libvirt"
+)
+
+type DomainController interface {
+	GetDomain(uuid string) (*domCon.Domain, error)
+	GetAllUUIDs() []string
+	GetDomainListStatus() *domStatus.DomainListStatus
+}
+
+type Handler struct {
+	LibvirtInst   *libvirt.Connect
+	DomainControl DomainController
+	Logger        *zap.Logger
+}
+
+func NewHandler(lv *libvirt.Connect, dc DomainController, logger *zap.Logger) *Handler {
+	return &Handler{
+		LibvirtInst:   lv,
+		DomainControl: dc,
+		Logger:        logger,
+	}
+}

--- a/api/Status/model.go
+++ b/api/Status/model.go
@@ -1,21 +1,21 @@
-package api
+package status
 
 import (
-	"github.com/easy-cloud-Knet/KWS_Core/services/status"
+	svcstatus "github.com/easy-cloud-Knet/KWS_Core/services/status"
 	"libvirt.org/go/libvirt"
 )
 
 type DomainStatusRequest struct {
-	DataType status.DomainDataType `json:"dataType"`
-	UUID     string                `json:"UUID"`
+	DataType svcstatus.DomainDataType `json:"dataType"`
+	UUID     string                   `json:"UUID"`
 }
 
 type HostStatusRequest struct {
-	HostDataType status.HostDataType `json:"host_dataType"`
+	HostDataType svcstatus.HostDataType `json:"host_dataType"`
 }
 
 type InstInfoRequest struct {
-	InstDataType status.InstDataType `json:"dataType"`
+	InstDataType svcstatus.InstDataType `json:"dataType"`
 }
 
 type UUIDListResponse struct {

--- a/api/Status/status_test.go
+++ b/api/Status/status_test.go
@@ -1,0 +1,177 @@
+package status
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	domCon "github.com/easy-cloud-Knet/KWS_Core/DomCon"
+	domStatus "github.com/easy-cloud-Knet/KWS_Core/DomCon/domainList_status"
+	virerr "github.com/easy-cloud-Knet/KWS_Core/internal/error"
+	svcstatus "github.com/easy-cloud-Knet/KWS_Core/services/status"
+	testutil "github.com/easy-cloud-Knet/KWS_Core/test"
+	"go.uber.org/zap"
+)
+
+// ─── mock ───────────────────────────────────────────────────────────────────
+
+type mockDomainController struct {
+	getDomainFn          func(uuid string) (*domCon.Domain, error)
+	getAllUUIDsFn         func() []string
+	getDomainListStatusFn func() *domStatus.DomainListStatus
+}
+
+func (m *mockDomainController) GetDomain(uuid string) (*domCon.Domain, error) {
+	return m.getDomainFn(uuid)
+}
+
+func (m *mockDomainController) GetAllUUIDs() []string {
+	return m.getAllUUIDsFn()
+}
+
+func (m *mockDomainController) GetDomainListStatus() *domStatus.DomainListStatus {
+	return m.getDomainListStatusFn()
+}
+
+func newTestHandler(dc DomainController) *Handler {
+	return &Handler{
+		DomainControl: dc,
+		Logger:        zap.NewNop(),
+	}
+}
+
+func domainErrMock() *mockDomainController {
+	return &mockDomainController{
+		getDomainFn: func(uuid string) (*domCon.Domain, error) {
+			return nil, virerr.ErrorGen(virerr.DomainSearchError, nil)
+		},
+	}
+}
+
+// ─── ReturnStatusUUID ────────────────────────────────────────────────────────
+
+func TestReturnStatusUUID_BadRequest(t *testing.T) {
+	h := newTestHandler(&mockDomainController{})
+	r := httptest.NewRequest(http.MethodGet, "/getStatusUUID", bytes.NewBufferString("invalid json"))
+	w := httptest.NewRecorder()
+
+	h.ReturnStatusUUID(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestReturnStatusUUID_InvalidDataType(t *testing.T) {
+	h := newTestHandler(&mockDomainController{})
+	// DomainDataType 99 는 DataTypeRouter 에서 에러 반환
+	r := testutil.MakeRequest(t, DomainStatusRequest{UUID: "test-uuid", DataType: svcstatus.DomainDataType(99)})
+	w := httptest.NewRecorder()
+
+	h.ReturnStatusUUID(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestReturnStatusUUID_GetDomainError(t *testing.T) {
+	h := newTestHandler(domainErrMock())
+	r := testutil.MakeRequest(t, DomainStatusRequest{UUID: "test-uuid", DataType: svcstatus.DomState})
+	w := httptest.NewRecorder()
+
+	h.ReturnStatusUUID(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+// ─── ReturnStatusHost ────────────────────────────────────────────────────────
+
+func TestReturnStatusHost_BadRequest(t *testing.T) {
+	h := newTestHandler(&mockDomainController{})
+	r := httptest.NewRequest(http.MethodGet, "/getStatusHost", bytes.NewBufferString("invalid json"))
+	w := httptest.NewRecorder()
+
+	h.ReturnStatusHost(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+func TestReturnStatusHost_InvalidHostDataType(t *testing.T) {
+	h := newTestHandler(&mockDomainController{})
+	// HostDataType 99 는 HostDataTypeRouter 에서 에러 반환
+	r := testutil.MakeRequest(t, HostStatusRequest{HostDataType: svcstatus.HostDataType(99)})
+	w := httptest.NewRecorder()
+
+	h.ReturnStatusHost(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+// ─── ReturnInstAllInfo ───────────────────────────────────────────────────────
+
+func TestReturnInstAllInfo_BadRequest(t *testing.T) {
+	h := newTestHandler(&mockDomainController{})
+	r := httptest.NewRequest(http.MethodGet, "/getInstAllInfo", bytes.NewBufferString("invalid json"))
+	w := httptest.NewRecorder()
+
+	h.ReturnInstAllInfo(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+func TestReturnInstAllInfo_InvalidInstDataType(t *testing.T) {
+	h := newTestHandler(&mockDomainController{})
+	// InstDataType 99 는 InstDataTypeRouter 에서 에러 반환
+	r := testutil.MakeRequest(t, InstInfoRequest{InstDataType: svcstatus.InstDataType(99)})
+	w := httptest.NewRecorder()
+
+	h.ReturnInstAllInfo(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+// ─── ReturnAllUUIDs ──────────────────────────────────────────────────────────
+
+func TestReturnAllUUIDs_EmptyList(t *testing.T) {
+	dc := &mockDomainController{
+		getAllUUIDsFn: func() []string { return []string{} },
+	}
+	h := newTestHandler(dc)
+	r := httptest.NewRequest(http.MethodGet, "/getAllUUIDs", nil)
+	w := httptest.NewRecorder()
+
+	h.ReturnAllUUIDs(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestReturnAllUUIDs_WithUUIDs(t *testing.T) {
+	dc := &mockDomainController{
+		getAllUUIDsFn: func() []string {
+			return []string{"uuid-1", "uuid-2", "uuid-3"}
+		},
+	}
+	h := newTestHandler(dc)
+	r := httptest.NewRequest(http.MethodGet, "/getAllUUIDs", nil)
+	w := httptest.NewRecorder()
+
+	h.ReturnAllUUIDs(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+	}
+}

--- a/cmd/doddle/init.go
+++ b/cmd/doddle/init.go
@@ -5,6 +5,7 @@ import (
 	"github.com/easy-cloud-Knet/KWS_Core/api"
 	control "github.com/easy-cloud-Knet/KWS_Core/api/Control"
 	create "github.com/easy-cloud-Knet/KWS_Core/api/Create"
+	apistatus "github.com/easy-cloud-Knet/KWS_Core/api/Status"
 	snapshot "github.com/easy-cloud-Knet/KWS_Core/api/Snapshot"
 	syslogger "github.com/easy-cloud-Knet/KWS_Core/internal/logger"
 	"go.uber.org/zap"
@@ -15,6 +16,7 @@ type App struct {
 	ControlHandler  *control.Handler
 	CreateHandler   *create.Handler
 	SnapshotHandler *snapshot.Handler
+	StatusHandler   *apistatus.Handler
 	Logger          *zap.Logger
 }
 
@@ -41,6 +43,7 @@ func initApp() *App {
 		ControlHandler:  control.NewHandler(domListCon, logger),
 		CreateHandler:   create.NewHandler(domListCon, inst.LibvirtInst, logger),
 		SnapshotHandler: snapshot.NewHandler(domListCon, logger),
+		StatusHandler:   apistatus.NewHandler(inst.LibvirtInst, domListCon, logger),
 		Logger:          logger,
 	}
 }

--- a/cmd/doddle/main.go
+++ b/cmd/doddle/main.go
@@ -19,6 +19,7 @@ func main() {
 		app.ControlHandler,
 		app.CreateHandler,
 		app.SnapshotHandler,
+		app.StatusHandler,
 		app.Logger)
 
 	select {}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,24 +7,25 @@ import (
 	"github.com/easy-cloud-Knet/KWS_Core/api"
 	control "github.com/easy-cloud-Knet/KWS_Core/api/Control"
 	create "github.com/easy-cloud-Knet/KWS_Core/api/Create"
+	apistatus "github.com/easy-cloud-Knet/KWS_Core/api/Status"
 	snapshot "github.com/easy-cloud-Knet/KWS_Core/api/Snapshot"
 	"github.com/easy-cloud-Knet/KWS_Core/internal/server/middleware"
 	"go.uber.org/zap"
 )
 
-func InitServer(portNum int, libvirtInst *api.InstHandler, controlHandler *control.Handler, createHandler *create.Handler, snapshotHandler *snapshot.Handler, logger *zap.Logger) {
+func InitServer(portNum int, libvirtInst *api.InstHandler, controlHandler *control.Handler, createHandler *create.Handler, snapshotHandler *snapshot.Handler, statusHandler *apistatus.Handler, logger *zap.Logger) {
 	logger.Sugar().Infof("Starting server on %d", portNum)
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("POST /BOOTVM", createHandler.BootVM)                      //post
-	mux.HandleFunc("POST /createVM", createHandler.CreateVMFromBase)          //post
-	mux.HandleFunc("GET /getStatusUUID", libvirtInst.ReturnStatusUUID)        //Get
-	mux.HandleFunc("POST /forceShutDownUUID", controlHandler.ForceShutDownVM) //POST
-	mux.HandleFunc("POST /DeleteVM", controlHandler.DeleteVM)                 //POST
-	mux.HandleFunc("GET /getStatusHost", libvirtInst.ReturnStatusHost)        //Get
-	mux.HandleFunc("GET /getInstAllInfo", libvirtInst.ReturnInstAllInfo)      //Get
-	mux.HandleFunc("GET /getAllUUIDs", libvirtInst.ReturnAllUUIDs)            //Get
-	mux.HandleFunc("GET /getAll-uuidstatusList", libvirtInst.ReturnAllDomainStates)
+	mux.HandleFunc("POST /BOOTVM", createHandler.BootVM)                         //post
+	mux.HandleFunc("POST /createVM", createHandler.CreateVMFromBase)             //post
+	mux.HandleFunc("GET /getStatusUUID", statusHandler.ReturnStatusUUID)         //Get
+	mux.HandleFunc("POST /forceShutDownUUID", controlHandler.ForceShutDownVM)    //POST
+	mux.HandleFunc("POST /DeleteVM", controlHandler.DeleteVM)                    //POST
+	mux.HandleFunc("GET /getStatusHost", statusHandler.ReturnStatusHost)         //Get
+	mux.HandleFunc("GET /getInstAllInfo", statusHandler.ReturnInstAllInfo)       //Get
+	mux.HandleFunc("GET /getAllUUIDs", statusHandler.ReturnAllUUIDs)             //Get
+	mux.HandleFunc("GET /getAll-uuidstatusList", statusHandler.ReturnAllDomainStates)
 
 	// Snapshot operations
 	mux.HandleFunc("POST /CreateSnapshot", snapshotHandler.CreateSnapshot)


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / tech debt
- [ ] Docs / test

## Summary
status api핸들러를 분리시키면서 종속성 제거. 
instHandler 지울 수 있을지는 다음 pr 에서 테스트하면서 할 예정

## Related Issue
Closes #138 

## Test Plan
- [ ] `make test` passes
- [ ] Manually verified on libvirt environment
