### PR TITLE
ci: add `apt-get update` before installing system dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,9 @@ jobs:
           cache: false
 
       - name: Install system dependencies
-        run: sudo apt-get install -y libvirt-dev pkg-config
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvirt-dev pkg-config
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,7 +19,9 @@ jobs:
           cache: true
 
       - name: Install system dependencies
-        run: sudo apt-get install -y libvirt-dev pkg-config whois
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvirt-dev pkg-config whois
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / tech debt
- [ ] Docs / test

## Summary
깃헙 러너 apt list는 우분투 미러 서버에서 삭제된 구버전을 가지고 있네요.  
워크플로우 돌아가는 시간은 조금 더 걸리겠지만 깃헙에서 스냅샷 올리기까지 얼마나 걸릴지 모르니 이렇게 명시적으로 apt update하는 게 어떨까 싶습니다.

## Related Issue
Closes #

## Test Plan
문제 발생할만한 곳이 없다고 판단하여 별다른 테스트는 진행하지 않았습니다. 